### PR TITLE
:sparkles: [Feat] Next.js App Router 중앙집중식 SEO 메타데이터 관리 시스템 구축 #35

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,7 +38,7 @@ export const metadata: Metadata = {
     telephone: false,
   },
   metadataBase: new URL(
-    process.env.NEXT_PUBLIC_BASE_URL || "https://weekly-apps.s3.amazonaws.com"
+    process.env.NEXT_PUBLIC_BASE_URL || "https://weekly-app.net"
   ),
   alternates: {
     canonical: "/",

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -3,8 +3,7 @@ import { MetadataRoute } from "next";
 export const dynamic = "force-static";
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl =
-    process.env.NEXT_PUBLIC_BASE_URL || "https://weekly-apps.s3.amazonaws.com";
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://weekly-app.net";
 
   return {
     rules: {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,8 +3,7 @@ import { MetadataRoute } from "next";
 export const dynamic = "force-static";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl =
-    process.env.NEXT_PUBLIC_BASE_URL || "https://weekly-apps.s3.amazonaws.com";
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://weekly-app.net";
 
   return [
     {


### PR DESCRIPTION
## 📌 개요
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- 이슈 번호: close #35

<br/>

## ✨ 개발 내용
<!-- 개발한 내용을 설명을 적어주세요 -->
Next.js App Router를 활용한 중앙집중식 SEO 메타데이터 관리 시스템을 구축했습니다.
  기존 S3 URL에서 프로덕션 도메인으로 변경하여 SEO 최적화를 진행했습니다.

  주요 변경사항:
  - src/app/layout.tsx: metadataBase URL을 https://weekly-apps.s3.amazonaws.com에서
  https://weekly-app.net으로 변경
  - src/app/robots.ts: robots.txt 생성 시 baseUrl을 프로덕션 도메인으로 변경
  - src/app/sitemap.ts: sitemap 생성 시 baseUrl을 프로덕션 도메인으로 변경
<br/>

## 🔥 변경 로직(optional)
<!-- 변경된 로직이 있다면 적어주세요. -->
- 기존에는 환경변수가 없을 때 fallback URL로 S3 버킷 주소를 사용했지만, 이제는 실제 프로덕션 도메인인 https://weekly-app.net을 사용하도록 변경했습니다. 이를 통해 검색엔진이 올바른 canonical URL을 인식할 수 있게 되었습니다.
<br/>

### 📸 스크린샷(optional)
<!-- 관련 스크린샷이 필요하다면 스크린샷을 첨부해주세요 -->

<br/>

### 👓 고민사항(optional)
- 환경변수 NEXT_PUBLIC_BASE_URL이 설정되지 않은 경우의 fallback URL을 S3에서 실제
  도메인으로 변경했는데, 이것이 다른 환경(개발, 스테이징)에서도 적절한지 검토가
  필요할 수 있습니다.
<br/>

### 📩 전달사항(optional)
- SEO 최적화를 위해 도메인을 변경했으므로, 검색 콘솔에서 새로운 sitemap과
  robots.txt가 정상적으로 인식되는지 확인해주세요.
<br/>

### 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들(optional)
<!-- 참고할 사항이 있다면 적어주세요 -->
- Next.js App Router의 metadataBase는 모든 상대 URL의 기준이 되는 중요한 설정입니다
- robots.ts와 sitemap.ts에서 export const dynamic = "force-static"를 사용하여 빌드 시 정적 파일로 생성됩니다
- 검색엔진 최적화를 위해서는 canonical URL의 일관성이 매우 중요합니다